### PR TITLE
Tweaking dynamic Select for confirmation #s

### DIFF
--- a/src/components/ClientManagmentUtils/BookingForm.tsx
+++ b/src/components/ClientManagmentUtils/BookingForm.tsx
@@ -17,24 +17,23 @@ const BookingForm: React.FC<BookingFormProps> = ({ clientId }) => {
     supplierFinalPaymentDate: '',
     bookingDate: '',
     invoicedDate: '',
-    confirmationNumbers: [''],
+    confirmationNumbers: [{ confirmationNumber: '', supplier: '' }],
     namesDateOfBirths: [{ name: '', dateOfBirth: '' }],
     mailingAddress: '',
     phoneNumbers: [''],
     emailAddresses: [''],
     significantDates: [''],
     bookingId: '',
-
   });
 
   const toast = useToast();
   const { saveBooking } = useBookingsData();
 
-  // This function handles adding a new booking
+  // Function to handle adding a new booking
   const handleAddBooking = () => {
     const newBooking = { ...formData, bookingId: new Date().toISOString() };
     saveBooking(clientId, newBooking);
-    
+
     toast({
       title: 'Booking added to client.',
       status: 'success',
@@ -50,27 +49,32 @@ const BookingForm: React.FC<BookingFormProps> = ({ clientId }) => {
       supplierFinalPaymentDate: '',
       bookingDate: '',
       invoicedDate: '',
-      confirmationNumbers: [''],
+      confirmationNumbers: [{ confirmationNumber: '', supplier: '' }],
       namesDateOfBirths: [{ name: '', dateOfBirth: '' }],
       mailingAddress: '',
       phoneNumbers: [''],
       emailAddresses: [''],
       significantDates: [''],
       bookingId: '',
-
     });
   };
 
   // Handle changes in form fields
-  const handleArrayChange = (field: keyof bookingFormData, index: number, value: string, subField?: string) => {
+  const handleArrayChange = (
+    field: keyof bookingFormData,
+    index: number,
+    value: string,
+    subField?: string
+  ) => {
     const updatedArray = [...(formData[field] as any)];
     if (subField) {
-      updatedArray[index][subField] = value;
+      (updatedArray[index] as any)[subField] = value;
     } else {
       updatedArray[index] = value;
     }
     setFormData({ ...formData, [field]: updatedArray });
   };
+  
 
   const handleAddField = (field: keyof bookingFormData, defaultValue: any) => {
     const updatedArray = [...(formData[field] as any), defaultValue];
@@ -145,25 +149,32 @@ const BookingForm: React.FC<BookingFormProps> = ({ clientId }) => {
 
           {/* Dynamic form fields */}
           <FormControl>
-            <FormLabel>Confirmation Numbers : Supplier (eg: 1242341 : Ramada Hotel)</FormLabel>
-            {formData.confirmationNumbers.map((number, index) => (
+            <FormLabel>Confirmation Number/Supplier</FormLabel>
+            {formData.confirmationNumbers.map((entry, index) => (
               <Box key={index} mb={2}>
                 <Input
                   type="text"
                   placeholder="Confirmation Number"
-                  value={number}
-                  onChange={(e) => handleArrayChange('confirmationNumbers', index, e.target.value)}
+                  value={entry.confirmationNumber}
+                  onChange={(e) => handleArrayChange('confirmationNumbers', index, e.target.value, 'confirmationNumber')}
+                />
+                <Input
+                  type="text"
+                  placeholder="Supplier"
+                  value={entry.supplier}
+                  onChange={(e) => handleArrayChange('confirmationNumbers', index, e.target.value, 'supplier')}
+                  mb={1}
                 />
                 <IconButton
                   icon={<DeleteIcon />}
-                  aria-label='Remove Confirmation Number'
+                  aria-label="Remove Confirmation Number"
                   onClick={() => handleRemoveField('confirmationNumbers', index)}
                   ml={2}
                 />
               </Box>
             ))}
-            <Button onClick={() => handleAddField('confirmationNumbers', '')} leftIcon={<AddIcon />}>
-              Add Confirmation Number
+            <Button onClick={() => handleAddField('confirmationNumbers', { confirmationNumber: '', supplier: '' })} leftIcon={<AddIcon />}>
+              Add Confirmation Number/Supplier
             </Button>
           </FormControl>
 
@@ -186,7 +197,7 @@ const BookingForm: React.FC<BookingFormProps> = ({ clientId }) => {
                 />
                 <IconButton
                   icon={<DeleteIcon />}
-                  aria-label='Remove Name and Date of Birth'
+                  aria-label="Remove Name and Date of Birth"
                   onClick={() => handleRemoveField('namesDateOfBirths', index)}
                   ml={2}
                   mt={1}
@@ -210,7 +221,7 @@ const BookingForm: React.FC<BookingFormProps> = ({ clientId }) => {
                 />
                 <IconButton
                   icon={<DeleteIcon />}
-                  aria-label='Remove Phone Number'
+                  aria-label="Remove Phone Number"
                   onClick={() => handleRemoveField('phoneNumbers', index)}
                   ml={2}
                 />
@@ -233,7 +244,7 @@ const BookingForm: React.FC<BookingFormProps> = ({ clientId }) => {
                 />
                 <IconButton
                   icon={<DeleteIcon />}
-                  aria-label='Remove Email Address'
+                  aria-label="Remove Email Address"
                   onClick={() => handleRemoveField('emailAddresses', index)}
                   ml={2}
                 />
@@ -256,7 +267,7 @@ const BookingForm: React.FC<BookingFormProps> = ({ clientId }) => {
                 />
                 <IconButton
                   icon={<DeleteIcon />}
-                  aria-label='Remove Significant Dates'
+                  aria-label="Remove Significant Dates"
                   onClick={() => handleRemoveField('significantDates', index)}
                   ml={2}
                 />

--- a/src/components/bookingFormUtils/displayBookingsData.tsx
+++ b/src/components/bookingFormUtils/displayBookingsData.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { Box, Text, IconButton } from '@chakra-ui/react';
+import dayjs from 'dayjs'; 
 import useBookingsData from './useBookingsData';
 import { bookingFormData } from '../generalUtils/interfaces';
 import ClosableBox2 from '../generalUtils/ClosableBox2';
@@ -21,7 +22,7 @@ const ClientBookings: React.FC<ClientBookingsProps> = ({ clientId }) => {
     const fetchBookings = () => {
       try {
         const clientBookings = getBookingsByClientId(clientId);
-        console.log('Fetched bookings:', clientBookings); // Debug log
+        console.log('Fetched bookings:', clientBookings); 
         setBookings(clientBookings);
       } catch (error) {
         console.error('Failed to fetch bookings:', error);
@@ -31,7 +32,7 @@ const ClientBookings: React.FC<ClientBookingsProps> = ({ clientId }) => {
     const fetchClientData = () => {
       try {
         const clients = JSON.parse(localStorage.getItem('ClientList') || '[]');
-        console.log('Fetched clients:', clients); // Debug log
+        console.log('Fetched clients:', clients);
         const client = clients.find((c: any) => c.id === clientId);
         if (client) {
           setClientName(client.clientName || '');
@@ -47,15 +48,27 @@ const ClientBookings: React.FC<ClientBookingsProps> = ({ clientId }) => {
 
   const handleDeleteClick = (bookingId: string) => {
     const updatedBookings = bookings.filter((b) => b.bookingId !== bookingId);
-    console.log('Updated bookings after delete:', updatedBookings); // Debug log
+    console.log('Updated bookings after delete:', updatedBookings);
     setBookings(updatedBookings);
+    handleSave(updatedBookings); // Save updated bookings
+  };
+
+  const handleSave = (updatedBookings: bookingFormData[]) => {
+    const formattedBookings = updatedBookings.map((booking) => ({
+      ...booking,
+      travelDate: dayjs(booking.travelDate).format('YYYY-MM-DD'),
+      clientFinalPaymentDate: dayjs(booking.clientFinalPaymentDate).format('YYYY-MM-DD'),
+      supplierFinalPaymentDate: dayjs(booking.supplierFinalPaymentDate).format('YYYY-MM-DD'),
+      bookingDate: dayjs(booking.bookingDate).format('YYYY-MM-DD'),
+      invoicedDate: dayjs(booking.invoicedDate).format('YYYY-MM-DD'),
+    }));
 
     try {
       const clients = JSON.parse(localStorage.getItem('ClientList') || '[]');
       const client = clients.find((c: any) => c.id === clientId);
       if (client) {
-        client.bookings = updatedBookings;
-        console.log('Updating client data in local storage:', clients); // Debug log
+        client.bookings = formattedBookings;
+        console.log('Updating client data in local storage:', clients);
         localStorage.setItem('ClientList', JSON.stringify(clients));
       }
     } catch (error) {
@@ -73,52 +86,56 @@ const ClientBookings: React.FC<ClientBookingsProps> = ({ clientId }) => {
         <Box w={{ base: '60vw', md: 'auto' }} borderRadius={"lg"}>
           {bookings.length > 0 ? (
             bookings.map((booking, index) => (
-              
-              <Box key={index}
-              bg={background}
-                  boxShadow="0px 0px 10px 5px gray"
-                  border="1px"
-                  borderColor="gray.200"
-                  borderRadius={"lg"}
-                  mt={4}
-                  mb={4}
+              <Box
+                key={index}
+                bg={background}
+                boxShadow="0px 0px 10px 5px gray"
+                border="1px"
+                borderColor="gray.200"
+                borderRadius={"lg"}
+                mt={4}
+                mb={4}
               >
                 <Box
                   display={"flex"}
                   flexDirection={{ base: 'column', md: 'row' }}
                   bg={background}
-                  
                   p={2}
                   mt={4}
                   mb={6}
                   borderRadius={"lg"}
                   w={"100%"}
-                  >
+                >
                   <Box
-                  
-                  display={"flex"}
-                  flexDirection="column"
-                  justifyContent={{ base: 'center', md: 'flex-start' }}
-                  alignItems={{ base: 'center', md: 'flex-start' }}
-                  w={"100%"}
+                    display={"flex"}
+                    flexDirection="column"
+                    justifyContent={{ base: 'center', md: 'flex-start' }}
+                    alignItems={{ base: 'center', md: 'flex-start' }}
+                    w={"100%"}
                   >
                     <Text fontSize={'lg'}>
-                      <Text as={'b'} color={accent} fontSize={'sm'}>Travel Date:</Text> {booking.travelDate}
+                      <Text as={'b'} color={accent} fontSize={'sm'}>Travel Date:</Text> {dayjs(booking.travelDate).format('YYYY-MM-DD')}
                     </Text>
                     <Text fontSize={'lg'}>
-                      <Text as={'b'} color={accent} fontSize={'sm'}>Client Final Payment Date:</Text> {booking.clientFinalPaymentDate}
+                      <Text as={'b'} color={accent} fontSize={'sm'}>Client Final Payment Date:</Text> {dayjs(booking.clientFinalPaymentDate).format('YYYY-MM-DD')}
                     </Text>
                     <Text fontSize={'lg'}>
-                      <Text as={'b'} color={accent} fontSize={'sm'}>Supplier Final Payment Date:</Text> {booking.supplierFinalPaymentDate}
+                      <Text as={'b'} color={accent} fontSize={'sm'}>Supplier Final Payment Date:</Text> {dayjs(booking.supplierFinalPaymentDate).format('YYYY-MM-DD')}
                     </Text>
                     <Text fontSize={'lg'}>
-                      <Text as={'b'} color={accent} fontSize={'sm'}>Booking Date:</Text> {booking.bookingDate}
+                      <Text as={'b'} color={accent} fontSize={'sm'}>Booking Date:</Text> {dayjs(booking.bookingDate).format('YYYY-MM-DD')}
                     </Text>
                     <Text fontSize={'lg'}>
-                      <Text as={'b'} color={accent} fontSize={'sm'}>Invoiced Date:</Text> {booking.invoicedDate}
+                      <Text as={'b'} color={accent} fontSize={'sm'}>Invoiced Date:</Text> {dayjs(booking.invoicedDate).format('YYYY-MM-DD')}
                     </Text>
                     <Text fontSize={'lg'}>
-                      <Text as={'b'} color={accent} fontSize={'sm'}>Confirmation Numbers:</Text> {booking.confirmationNumbers.join(', ')}
+                      <Text as={'b'} color={accent} fontSize={'sm'}>Confirmation Numbers/Suppliers:</Text> 
+                      {booking.confirmationNumbers.map((entry, i) => (
+                        <span key={i}>
+                          | {entry.confirmationNumber} : {entry.supplier} |
+                          {i < booking.confirmationNumbers.length - 1 ? ', ' : ''}
+                        </span>
+                      ))}
                     </Text>
                     <Text fontSize={'lg'}>
                       <Text as={'b'} color={accent} fontSize={'sm'}>Names and Date of Births:</Text> {booking.namesDateOfBirths.map((entry, i) => (
@@ -137,16 +154,11 @@ const ClientBookings: React.FC<ClientBookingsProps> = ({ clientId }) => {
                     <Text fontSize={'lg'}>
                       <Text as={'b'} color={accent} fontSize={'sm'}>Significant Dates:</Text> {booking.significantDates.join(', ')}
                     </Text>
-                  
-                    
                   </Box>
                   <Box>
                     <BookingChecklist clientId={clientId} bookingId={booking.bookingId ?? ''} />
                   </Box>
                 </Box>
-                  
-                
-                  
                 <Box
                   display="flex"
                   flexDirection="row"

--- a/src/components/calculatorUtils/commissionForm.tsx
+++ b/src/components/calculatorUtils/commissionForm.tsx
@@ -3,6 +3,7 @@ import { Box, FormControl, FormLabel, Input, Checkbox, Button, SimpleGrid, Numbe
 import { useBrandColors } from '../generalUtils/theme'
 import useBookingsData from '../bookingFormUtils/useBookingsData'
 import useClientData from '../ClientManagmentUtils/UseClientDataHook'
+import dayjs from 'dayjs'
 
 // Interface for the commission form data
 interface CommissionFormData {
@@ -22,7 +23,7 @@ interface CommissionFormData {
 const CommissionForm = () => {
   const { primary, background, secondary, accent, text } = useBrandColors()
   const [selectedClientId, setSelectedClientId] = useState<number | null>(null) 
-  const [selectedBookingTravelDate, setSelectedBookingTravelDate] = useState<string | number | null>(null) 
+  const [selectedBookingTravelDate, setSelectedBookingTravelDate] = useState<string | null>(null) 
   const [selectedConfirmationNumber, setSelectedConfirmationNumber] = useState<string | null>(null)
   const [bookings, setBookings] = useState<any[]>([])
 
@@ -58,16 +59,16 @@ const CommissionForm = () => {
   }, [selectedClientId, getBookingsByClientId])
 
   // Fetch the booking's confirmation numbers whenever a booking travel date is selected
-useEffect(() => {
-  if (selectedBookingTravelDate !== null) {
-    const booking = bookings.find((b: any) => b.travelDate === selectedBookingTravelDate)
-    if (booking) {
-      setSelectedConfirmationNumber('') // Reset to the placeholder value when a new booking is selected
+  useEffect(() => {
+    if (selectedBookingTravelDate !== null) {
+      const booking = bookings.find((b: any) => b.travelDate === selectedBookingTravelDate)
+      if (booking) {
+        setSelectedConfirmationNumber('') // Reset to the placeholder value when a new booking is selected
+      }
+    } else {
+      setSelectedConfirmationNumber(null)
     }
-  } else {
-    setSelectedConfirmationNumber(null)
-  }
-}, [selectedBookingTravelDate, bookings])
+  }, [selectedBookingTravelDate, bookings])
 
   // Handle input changes
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -96,38 +97,31 @@ useEffect(() => {
       <form onSubmit={handleSubmit}>
         <SimpleGrid columns={{ base: 1, md: 2 }} spacing={4}>
           {/* Client Selection */}
-          <FormControl color={accent}
-          >
+          <FormControl color={accent}>
             <FormLabel htmlFor='clientName'>Client Name</FormLabel>
             <Select
-            
-                boxShadow="0px 0px 5px 1px"
-            
-             outline={'1px solid'}
+              boxShadow="0px 0px 5px 1px"
+              outline={'1px solid'}
               outlineColor={accent}
               id='clientName'
               color={text}
               value={selectedClientId !== null ? selectedClientId : ''}  
               onChange={(e) => setSelectedClientId(Number(e.target.value))}
             >
-              <option
-              
-              value=""
-              >Select Client</option>
+              <option value="">Select Client</option>
               {clientData.map((client) => (
-                <option  key={client.id} value={client.id}>{client.clientName}</option> 
+                <option key={client.id} value={client.id}>{client.clientName}</option> 
               ))}
             </Select>
           </FormControl>
 
-
-         {/* Booking Selection - Show only if a client is selected */}
+          {/* Booking Selection - Show only if a client is selected */}
           {selectedClientId && (
             <FormControl color={accent}>
               <FormLabel htmlFor='booking'>Booking</FormLabel>
               <Select
-              outline={'1px solid'}
-              outlineColor={accent}
+                outline={'1px solid'}
+                outlineColor={accent}
                 id='booking'
                 color={text}
                 boxShadow="0px 0px 5px 1px"
@@ -135,9 +129,15 @@ useEffect(() => {
                 onChange={(e) => setSelectedBookingTravelDate(e.target.value)}  // Store the raw value directly
               >
                 <option value="">Select Booking</option>
-                {bookings.map((booking) => (
-                  <option key={booking.travelDate} value={booking.travelDate}>Travel Date: {new Date(booking.travelDate).toLocaleDateString()}</option> // Format the date properly
-                ))}
+                {bookings.map((booking) => {
+                  // Parse the date using dayjs
+                  const localDate = dayjs(booking.travelDate).format('YYYY-MM-DD'); // Adjust format as needed
+                  return (
+                    <option key={booking.travelDate} value={booking.travelDate}>
+                      Travel Date: {localDate}
+                    </option>
+                  );
+                })}
               </Select>
             </FormControl>
           )}
@@ -145,7 +145,7 @@ useEffect(() => {
           {/* Confirmation Number selection - show only if a booking travel date is selected */}
           {selectedBookingTravelDate && (
             <FormControl color={accent}>
-              <FormLabel htmlFor='confirmationNumber'>Confirmation Number</FormLabel>
+              <FormLabel htmlFor='confirmationNumber'>Confirmation Number : Supplier</FormLabel>
               <Select
                 outline={'1px solid'}
                 outlineColor={accent}
@@ -155,34 +155,34 @@ useEffect(() => {
                 value={selectedConfirmationNumber !== null ? selectedConfirmationNumber : ''}  // Keep placeholder when no selection is made
                 onChange={(e) => setSelectedConfirmationNumber(e.target.value)}  // Update the value when selected
               >
-                <option value="">Select Confirmation Number</option>
+                <option value="">Select Confirmation Number : Supplier</option>
                 {bookings
-                  .find((b: any) => b.travelDate === selectedBookingTravelDate)?.confirmationNumbers?.map((confirmationNumber: string) => (
-                    <option key={confirmationNumber} value={confirmationNumber}>
-                      {confirmationNumber}
-                    </option>
-                  ))}
+                  .find((b: any) => b.travelDate === selectedBookingTravelDate)?.confirmationNumbers?.map((confirmation: any) => {
+                    const booking = bookings.find((b: any) => b.travelDate === selectedBookingTravelDate);
+                    const supplier = booking?.confirmationNumbers.find((c: any) => c.confirmationNumber === confirmation.confirmationNumber)?.supplier || 'Unknown Supplier';  // Use a default value if supplier is not available
+                    return (
+                      <option key={confirmation.confirmationNumber} value={confirmation.confirmationNumber}>
+                        {confirmation.confirmationNumber} : {supplier}
+                      </option>
+                    );
+                  })}
               </Select>
             </FormControl>
           )}
 
-
-
-         
-
           {/* Booking Number Input */}
-          <FormControl color={accent}>
+          {/* <FormControl color={accent}>
             <FormLabel htmlFor='bookingNumber'>Booking Number</FormLabel>
             <NumberInput defaultValue={0} precision={0}>
               <NumberInputField id='bookingNumber' color={text} value={formData.bookingNumber} onChange={handleChange} />
             </NumberInput>
-          </FormControl>
+          </FormControl> */}
 
-           {/* Supplier Input */}
-          <FormControl color={accent}>
+          {/* Supplier Input */}
+          {/* <FormControl color={accent}>
             <FormLabel htmlFor='supplier'>Supplier</FormLabel>
             <Input id='supplier' color={text} type='text' value={formData.supplier} onChange={handleChange} />
-          </FormControl>
+          </FormControl> */}
 
           {/* Final Payment Date */}
           <FormControl color={accent}>

--- a/src/components/generalUtils/interfaces.tsx
+++ b/src/components/generalUtils/interfaces.tsx
@@ -6,17 +6,15 @@ export interface bookingFormData {
   supplierFinalPaymentDate: string;
   bookingDate: string;
   invoicedDate: string;
-  confirmationNumbers: string[];
+  confirmationNumbers: { confirmationNumber: string; supplier: string }[];
   namesDateOfBirths: { name: string; dateOfBirth: string }[];
   mailingAddress: string;
   phoneNumbers: string[];
   emailAddresses: string[];
   significantDates: string[];
-  bookingId?: string;
-  checklists?: {
-    [key: string]: boolean;
-  };
+  bookingId: string;
 }
+
 
 // NewClientFormData interface
 export interface newClientFormData {


### PR DESCRIPTION
Fixing issue in commission form. Proper booking travel dates now populate the Select menu, and Confirmation Number/Supplier select now properly displays the correct numbers/suppliers according to which booking was chosen by travel date.